### PR TITLE
Remove Spring dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,6 @@
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>4.3.13.RELEASE</version>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/test/java/dk/dsg/StepMarkupTest.java
+++ b/src/test/java/dk/dsg/StepMarkupTest.java
@@ -17,7 +17,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.springframework.util.StringUtils;
 
 @RunWith(Parameterized.class)
 public class StepMarkupTest {
@@ -37,7 +36,7 @@ public class StepMarkupTest {
 
 		Assert.assertEquals(expected, stepMarkup.parse(input));
 
-		final int hrefs = StringUtils.countOccurrencesOf(input, " href=\"");
+		final int hrefs = countOccurrencesOf(input, " href=\"");
 		Assert.assertEquals(hrefs, stepMarkup.anchors().size());
 	}
 
@@ -81,5 +80,18 @@ public class StepMarkupTest {
 				return reader.lines().collect(Collectors.joining("\n"));
 			}
 		}
+	}
+
+	private static int countOccurrencesOf(
+			final String haystack,
+			final String needle) {
+		int count = 0;
+		int from = 0;
+		int idx;
+		while ((idx = haystack.indexOf(needle, from)) > -1) {
+			++count;
+			from = idx + needle.length();
+		}
+		return count;
 	}
 }


### PR DESCRIPTION
About a dozen vulnerabilities in Spring were just published. These are
all related to HTTP and completely irrelevant here. However, we only use
Spring for a silly utility method -- better to eliminate the dependency
and not have to deal with Spring's surface area.